### PR TITLE
Zero --> Null for missing values

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -119,9 +119,9 @@
                 "ru": "Werte nullen (übersetzen)"
             },
             "Der Adapter ...": {
-                "en": "The adapter resets all prices before every scheduled refresh. This function prevents from saving outdated values if any error occurs while updating from the tankerkoenig-server.<br>To keep the data fluently without zeroes tick off this box.",
-                "de": "Der Adapter setzt bei jeder Aktualisierung der Preise vorher den Wert 0. Damit wird verhindert, dass sich ein veralteter Preis über evtl. Störungen bei der Aktualisierung hinweg hält.<br>Wenn Sie den Haken entfernen, wird keine 0 gesetzt. Damit werden Aufzeichnungen gleichmäßiger.",
-                "ru": "Der Adapter setzt bei jeder Aktualisierung der Preise vorher den Wert 0. Damit wird verhindert, dass sich ein veralteter Preis über evtl. Störungen bei der Aktualisierung hinweg hält.<br>Wenn Sie den Haken entfernen, wird keine 0 gesetzt. Damit werden Aufzeichnungen gleichmäßiger. (übersetzen)"
+                "en": "The adapter resets all prices before every scheduled refresh. This function prevents from saving outdated values if any error occurs while updating from the tankerkoenig-server.<br>To keep the data fluently without null values tick off this box.",
+                "de": "Der Adapter setzt bei jeder Aktualisierung der Preise vorher den Wert null. Damit wird verhindert, dass sich ein veralteter Preis über evtl. Störungen bei der Aktualisierung hinweg hält.<br>Wenn Sie den Haken entfernen, wird der Wert nicht auf null gesetzt. Damit werden Aufzeichnungen durchgängig.",
+                "ru": "Der Adapter setzt bei jeder Aktualisierung der Preise vorher den Wert null. Damit wird verhindert, dass sich ein veralteter Preis über evtl. Störungen bei der Aktualisierung hinweg hält.<br>Wenn Sie den Haken entfernen, wird der Wert nicht auf null gesetzt. Damit werden Aufzeichnungen durchgängig. (übersetzen)"
             },
             "Reset": {
                 "en": "Reset values",

--- a/main.js
+++ b/main.js
@@ -85,28 +85,28 @@ function readData(url) {
                     // Reset
                     if (adapter.config.resetValues) {
                         // billigstes E5
-                        adapter.setState('stations.cheapest.e5.feed',  0);
-                        adapter.setState('stations.cheapest.e5.short', '');
-                        adapter.setState('stations.cheapest.e5.3rd',   0);// dritte stelle
+                        adapter.setState('stations.cheapest.e5.feed', null);
+                        adapter.setState('stations.cheapest.e5.short', null);
+                        adapter.setState('stations.cheapest.e5.3rd', null);// dritte stelle
                         adapter.setState('stations.cheapest.e5.combined', 'keine Daten');
-                        adapter.setState('stations.cheapest.e5.name', '');
-                        adapter.setState('stations.cheapest.e5.status', '');
+                        adapter.setState('stations.cheapest.e5.name', null);
+                        adapter.setState('stations.cheapest.e5.status', null);
 
                         // billigstes E10
-                        adapter.setState('stations.cheapest.e10.feed',  0);
-                        adapter.setState('stations.cheapest.e10.short', '0');
-                        adapter.setState('stations.cheapest.e10.3rd',   0);
+                        adapter.setState('stations.cheapest.e10.feed', null);
+                        adapter.setState('stations.cheapest.e10.short', null);
+                        adapter.setState('stations.cheapest.e10.3rd', null);
                         adapter.setState('stations.cheapest.e10.combined', 'keine Daten');
-                        adapter.setState('stations.cheapest.e10.name', '');
-                        adapter.setState('stations.cheapest.e10.status', '');
+                        adapter.setState('stations.cheapest.e10.name', null);
+                        adapter.setState('stations.cheapest.e10.status', null);
 
                         // billigster Diesel
-                        adapter.setState('stations.cheapest.diesel.feed',  0);
-                        adapter.setState('stations.cheapest.diesel.short', '0');// zweistellig
-                        adapter.setState('stations.cheapest.diesel.3rd',   0);// dritte stelle
+                        adapter.setState('stations.cheapest.diesel.feed', null);
+                        adapter.setState('stations.cheapest.diesel.short', null);// zweistellig
+                        adapter.setState('stations.cheapest.diesel.3rd', null);// dritte stelle
                         adapter.setState('stations.cheapest.diesel.combined', 'keine Daten');
-                        adapter.setState('stations.cheapest.diesel.name', '');
-                        adapter.setState('stations.cheapest.diesel.status', '');
+                        adapter.setState('stations.cheapest.diesel.name', null);
+                        adapter.setState('stations.cheapest.diesel.status', null);
                     }
 
 
@@ -118,17 +118,17 @@ function readData(url) {
                         // hier alle States für Status und Preise leeren (0.00 oder 0), falls nicht alle 10 Felder ausgefüllt sind (ohne ack true)
                         if (adapter.config.resetValues) { // Zeile testweise eingefügt
                         adapter.setState('stations.' + i + '.status',      '');
-                        adapter.setState('stations.' + i + '.e5.feed',      0);
-                        adapter.setState('stations.' + i + '.e5.short',     0);
-                        adapter.setState('stations.' + i + '.e5.3rd',       0);
+                        adapter.setState('stations.' + i + '.e5.feed',      null);
+                        adapter.setState('stations.' + i + '.e5.short',     null);
+                        adapter.setState('stations.' + i + '.e5.3rd',       null);
                         adapter.setState('stations.' + i + '.e5.combined', "");
-                        adapter.setState('stations.' + i + '.e10.feed',     0);
-                        adapter.setState('stations.' + i + '.e10.short',    0);
-                        adapter.setState('stations.' + i + '.e10.3rd',      0);
+                        adapter.setState('stations.' + i + '.e10.feed',     null);
+                        adapter.setState('stations.' + i + '.e10.short',    null);
+                        adapter.setState('stations.' + i + '.e10.3rd',      null);
                         adapter.setState('stations.' + i + '.e10.combined', "");
-                        adapter.setState('stations.' + i + '.diesel.feed',  0);
-                        adapter.setState('stations.' + i + '.diesel.short', 0);
-                        adapter.setState('stations.' + i + '.diesel.3rd',   0);
+                        adapter.setState('stations.' + i + '.diesel.feed',  null);
+                        adapter.setState('stations.' + i + '.diesel.short', null);
+                        adapter.setState('stations.' + i + '.diesel.3rd',   null);
                         adapter.setState('stations.' + i + '.diesel.combined', "");
                         } // Zeile testweise eingefügt
                         if (stationid.length == 36) { // wenn StationID bekannt, also Settings-Feld gefüllt


### PR DESCRIPTION

For flot charts, null values would be better than zero values.
In flot, it can be configured if null values should be null, ignored or zero.

<img width="1518" alt="bildschirmfoto 2018-01-25 um 00 08 59" src="https://user-images.githubusercontent.com/6996127/35362060-0b7f4432-0164-11e8-8e00-429a6672bbe1.png">

It seems, that I mistakenly forked the adapter from Apollon77 and not Pix.
I don´t currently know, how to create a pull request to Pix fork without commits from Apollon77 (already an existing pull reuest).
Sorry for that. ;-)